### PR TITLE
fix download of raw data to return a buffer instead of a string

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-rfc",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "description": "nodejs bindings for SAP NW RFC Library",
   "main": "index.js",
   "directories": {

--- a/src/rfcio.cc
+++ b/src/rfcio.cc
@@ -383,8 +383,8 @@ Handle<Value> wrapVariable(RFCTYPE typ, RFC_FUNCTION_HANDLE functionHandle, SAP_
 				free(byteValue);
 				break;
 			}
-			resultValue = Nan::New(reinterpret_cast<const char*>(byteValue)).ToLocalChecked();
-			free(byteValue);
+			resultValue = Nan::NewBuffer(reinterpret_cast<char*>(byteValue), cLen).ToLocalChecked();
+			// do not free byteValue - it will be freed when the buffer is garbage collected
 			break;
 		}
 		case RFCTYPE_XSTRING: {


### PR DESCRIPTION
This fix makes it possible to correctly retrieve data that is stored as RAW - data is returned as a UInt8Array of the raw data bytes.
Without this fix, if the the data type is RFCTYPE_BYTE (i.e. RAW), then it is returned as a string which corrupts the data in javascript land.