### PR TITLE
Fix Linux build error

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,7 +103,7 @@ else()
 endif()
 
 # source files and target library
-add_library(${PROJECT_NAME} SHARED src/node_sapnwrfc.cc src/client.cc src/rfcio.cc src/error.cc)
+add_library(${PROJECT_NAME} SHARED src/node_sapnwrfc.cc src/Client.cc src/rfcio.cc src/error.cc)
 
 # build path ignored on Windows, copy after build
 if ( MSVC )


### PR DESCRIPTION
Linux is case sensitive.

CMake Error at CMakeLists.txt:82 (add_library):
  Cannot find source file:
    src/client.cc

-
node-rfc/src/Client.cc
