### PR TITLE
Track handle status

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,7 +67,7 @@ if (NOT DEFINED ENV{NODE_HEADERS_INCLUDE_DIR})
         message("Downloading ${NODE_HEADERS_FILENAME} to ${NODE_HEADERS_DOWNLD_PATH} ...")
         file(DOWNLOAD "https://nodejs.org/download/release/${NODE_VERSION}/${NODE_HEADERS_FILENAME}" "${NODE_HEADERS_DOWNLD_PATH}" ) # SHOW_PROGRESS)
 
-        execute_process(COMMAND tar -xzf ${NODE_HEADERS_DOWNLD_PATH})
+        execute_process(COMMAND tar -xzf ${NODE_HEADERS_DOWNLD_PATH} --force-local)
         file(REMOVE ${NODE_HEADERS_DOWNLD_PATH})
         file(RENAME "${CMAKE_CURRENT_BINARY_DIR}/node-${NODE_VERSION}/include" "${NODE_HEADERS_INCLUDE_DIR}")
         file(REMOVE_RECURSE "${CMAKE_CURRENT_BINARY_DIR}/node-${NODE_VERSION}")


### PR DESCRIPTION
Trying to fix (or at least improve) #128 and #147, based on the theory that  the 1:1 relation between Clients and connectionHandles gets messed up (by an explicit or implicit close), at which point the Client mutexes no longer protect against multiple threads using the same connectionHandle. Main example: when the `Client` destructor closes a handle that has already been closed in that `Client` but has since been reopened by another `Client`.

This PR is possibly overly paranoid in some cases and most likely does not close all holes yet, but here is what it tries to do:

1. avoid closing a handle in the Client destructor if the Client may have lost exclusivity for that handle
2. try to tighten the management of Client->alive to more accurately track the handle status (reduce the time windows where multiple threads might see incorrect values)
