### PR TITLE
Update sapnwrfc-client.d.ts

### DIFF
--- a/lib/wrapper/sapnwrfc-client.d.ts
+++ b/lib/wrapper/sapnwrfc-client.d.ts
@@ -7,7 +7,7 @@ declare enum RfcParameterDirection {
     RFC_CHANGING = 3,
     RFC_TABLES = 7
 }
-export declare type RfcConnectionParameters = Partial<Record<RfcConnectionParametersAllowed, string>>;
+export declare type RfcConnectionParameters = Record<RfcConnectionParametersAllowed, string>;
 export declare type RfcClientOptions = {
     bcd?: string | Function;
     date?: Function;

--- a/lib/wrapper/sapnwrfc-client.d.ts
+++ b/lib/wrapper/sapnwrfc-client.d.ts
@@ -7,7 +7,7 @@ declare enum RfcParameterDirection {
     RFC_CHANGING = 3,
     RFC_TABLES = 7
 }
-export declare type RfcConnectionParameters = Record<RfcConnectionParametersAllowed, string>;
+export declare type RfcConnectionParameters = Partial<Record<RfcConnectionParametersAllowed, string>>;
 export declare type RfcClientOptions = {
     bcd?: string | Function;
     date?: Function;

--- a/src/ts/wrapper/sapnwrfc-client.ts
+++ b/src/ts/wrapper/sapnwrfc-client.ts
@@ -167,10 +167,10 @@ enum RfcParameterDirection {
     RFC_TABLES = 0x04 | RFC_CHANGING, ///< Table parameter. This corresponds to ABAP TABLES parameter.
 }
 
-export type RfcConnectionParameters = Record<
+export type RfcConnectionParameters = Partial<Record<
     RfcConnectionParametersAllowed,
     string
->;
+>>;
 
 export type RfcClientOptions = {
     bcd?: string | Function;


### PR DESCRIPTION
not all parameters for connection is needed. By adding partial, we won't get errors in typescript.

Fix #243 