### PR TITLE
Fixed memory leak for RFCTYPE_XSTRING

### DIFF
--- a/src/nwrfcsdk.cc
+++ b/src/nwrfcsdk.cc
@@ -615,8 +615,9 @@ namespace node_rfc
                 free(byteValue);
                 break;
             }
-            resultValue = Napi::Buffer<SAP_RAW>::New(node_rfc::__env, reinterpret_cast<SAP_RAW *>(byteValue), resultLen);
-            // do not free byteValue - it will be freed when the buffer is garbage collected
+            resultValue = Napi::Buffer<SAP_RAW>::New(node_rfc::__env, reinterpret_cast<SAP_RAW *>(byteValue), resultLen, [](Env env, SAP_RAW *garbage) {
+                free(garbage);
+            });
             break;
         }
         case RFCTYPE_BCD:


### PR DESCRIPTION
Allocated `byteValue` in nwrfcsdk.cc:618 is not freed automatically (a fact that only becomes apparent if you transfer very large XSTRING types) resulting in a memory leak that is significant for applications that deal with large amounts of XSTRING data (my app would, for instance, would crash after a few minutes due to lack of memory - others will likely not experience it on this kind of scale, but the memory leak is nevertheless a concern in my opinion).

The fix is very simple and uses the finalizer feature of `node-addon-api`. Looking forward to your comments